### PR TITLE
Add ability to put the whole Proxy instance into offline mode

### DIFF
--- a/config/env.go
+++ b/config/env.go
@@ -53,6 +53,7 @@ func (c *Config) loadEnv() {
 	c.Tls.loadEnv(envPrefix)
 	c.Metrics.loadEnv(envPrefix)
 	c.Cache.loadEnv(envPrefix)
+	c.GlobalOfflineConfig.loadEnv(envPrefix)
 
 	readEnv(envPrefix, "DEFAULT_USER_ATTRIBUTES", &c.DefaultAttrs, toStringMap)
 }
@@ -93,6 +94,13 @@ func (h *HttpProxyConfig) loadEnv(prefix string) {
 func (c *CacheConfig) loadEnv(prefix string) {
 	prefix = concatPrefix(prefix, "CACHE")
 	c.Redis.loadEnv(prefix)
+}
+
+func (g *GlobalOfflineConfig) loadEnv(prefix string) {
+	prefix = concatPrefix(prefix, "OFFLINE")
+	readEnv(prefix, "ENABLED", &g.Enabled, toBool)
+	readEnv(prefix, "CACHE_POLL_INTERVAL", &g.CachePollInterval, toInt)
+	g.Log.loadEnv(prefix)
 }
 
 func (o *OfflineConfig) loadEnv(prefix string) {

--- a/config/env_test.go
+++ b/config/env_test.go
@@ -115,6 +115,19 @@ func TestMetricsConfig_ENV(t *testing.T) {
 	assert.Equal(t, 8091, conf.Metrics.Port)
 }
 
+func TestGlobalOfflineConfig_ENV(t *testing.T) {
+	t.Setenv("CONFIGCAT_OFFLINE_ENABLED", "true")
+	t.Setenv("CONFIGCAT_OFFLINE_CACHE_POLL_INTERVAL", "200")
+	t.Setenv("CONFIGCAT_OFFLINE_LOG_LEVEL", "info")
+
+	conf, err := LoadConfigFromFileAndEnvironment("")
+	require.NoError(t, err)
+
+	assert.True(t, conf.GlobalOfflineConfig.Enabled)
+	assert.Equal(t, 200, conf.GlobalOfflineConfig.CachePollInterval)
+	assert.Equal(t, log.Info, conf.GlobalOfflineConfig.Log.GetLevel())
+}
+
 func TestHttpConfig_ENV(t *testing.T) {
 	t.Setenv("CONFIGCAT_HTTP_PORT", "8090")
 	t.Setenv("CONFIGCAT_HTTP_LOG_LEVEL", "info")

--- a/config/validate.go
+++ b/config/validate.go
@@ -24,6 +24,9 @@ func (c *Config) Validate() error {
 	if err := c.Cache.Redis.validate(); err != nil {
 		return err
 	}
+	if err := c.GlobalOfflineConfig.validate(&c.Cache); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -76,6 +79,19 @@ func (o *OfflineConfig) validate(c *CacheConfig, sdkId string) error {
 	}
 	if o.UseCache && o.CachePollInterval < 1 {
 		return fmt.Errorf("sdk-" + sdkId + ": cache poll interval must be greater than 1 seconds")
+	}
+	return nil
+}
+
+func (g *GlobalOfflineConfig) validate(c *CacheConfig) error {
+	if !g.Enabled {
+		return nil
+	}
+	if !c.Redis.Enabled {
+		return fmt.Errorf("offline: global offline mode enabled, but no cache is configured")
+	}
+	if g.CachePollInterval < 1 {
+		return fmt.Errorf("offline: cache poll interval must be greater than 1 seconds")
 	}
 	return nil
 }

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -42,8 +42,16 @@ func TestConfig_Validate(t *testing.T) {
 		require.ErrorContains(t, conf.Validate(), "sdk-env1: offline mode enabled with cache, but no cache is configured")
 	})
 	t.Run("offline cache invalid poll interval", func(t *testing.T) {
-		conf := Config{SDKs: map[string]*SDKConfig{"env1": {Key: "Key", Offline: OfflineConfig{Enabled: true, UseCache: true, CachePollInterval: 0}}}, Cache: CacheConfig{Redis: RedisConfig{}}}
-		require.ErrorContains(t, conf.Validate(), "sdk-env1: offline mode enabled with cache, but no cache is configured")
+		conf := Config{SDKs: map[string]*SDKConfig{"env1": {Key: "Key", Offline: OfflineConfig{Enabled: true, UseCache: true, CachePollInterval: 0}}}, Cache: CacheConfig{Redis: RedisConfig{Enabled: true, Addresses: []string{"localhost"}}}}
+		require.ErrorContains(t, conf.Validate(), "sdk-env1: cache poll interval must be greater than 1 seconds")
+	})
+	t.Run("global offline cache invalid poll interval", func(t *testing.T) {
+		conf := Config{SDKs: map[string]*SDKConfig{"env1": {Key: "Key"}}, Cache: CacheConfig{Redis: RedisConfig{Enabled: true, Addresses: []string{"localhost"}}}, GlobalOfflineConfig: GlobalOfflineConfig{Enabled: true, CachePollInterval: -1}}
+		require.ErrorContains(t, conf.Validate(), "offline: cache poll interval must be greater than 1 seconds")
+	})
+	t.Run("global offline cache without cache", func(t *testing.T) {
+		conf := Config{SDKs: map[string]*SDKConfig{"env1": {Key: "Key"}}, GlobalOfflineConfig: GlobalOfflineConfig{Enabled: true}}
+		require.ErrorContains(t, conf.Validate(), "offline: global offline mode enabled, but no cache is configured")
 	})
 	t.Run("redis enabled without addresses", func(t *testing.T) {
 		conf := Config{SDKs: map[string]*SDKConfig{"env1": {Key: "Key"}}, Cache: CacheConfig{Redis: RedisConfig{Enabled: true}}}

--- a/sdk/user_agent.go
+++ b/sdk/user_agent.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 )
 
-const proxyVersion = "0.1.4"
+const proxyVersion = "0.1.5"
 
 type userAgentInterceptor struct {
 	http.RoundTripper


### PR DESCRIPTION
### Describe the purpose of your pull request

This PR adds the ability to put the whole Proxy instance into offline mode.
It requires a configured external cache.

### Related issues (only if applicable)

n/a

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
