### PR TITLE
Default options yml

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -182,7 +182,6 @@ func LoadConfigFromFileAndEnvironment(filePath string) (Config, error) {
 			return Config{}, fmt.Errorf("failed to parse YAML from config file %s: %s", realPath, err)
 		}
 	} else if defaultPath, ok := defaultConfigPath(); ok {
-		fmt.Println(defaultPath)
 		_, err := os.Stat(defaultPath)
 		if !errors.Is(err, os.ErrNotExist) {
 			data, err := os.ReadFile(defaultPath)

--- a/sdk/user_agent.go
+++ b/sdk/user_agent.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 )
 
-const proxyVersion = "0.1.5"
+const proxyVersion = "0.1.6"
 
 type userAgentInterceptor struct {
 	http.RoundTripper


### PR DESCRIPTION
### Describe the purpose of your pull request

This PR adds the ability to load `options.yml` from a default location.

The default location varies by platform:
- **Windows**: `%PROGRAMDATA%\configcat\proxy\options.yml`, usually `C:\ProgramData\configcat\proxy\options.yml`
- **macOS**: `/Library/Application Support/configcat/proxy/options.yml`
- **Linux**: `/etc/configcat/proxy/options.yml`

### Requirement checklist (only if applicable)

- [ ] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
