### PR TITLE
CORS origin regex

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -506,7 +506,22 @@ http:
 		assert.Equal(t, `.*\.example1\.com`, conf.Http.Sse.CORS.AllowedOriginsRegex.Patterns[0])
 		assert.Equal(t, `.*\.example2\.com`, conf.Http.Sse.CORS.AllowedOriginsRegex.Patterns[1])
 		assert.Equal(t, "https://example1.com", conf.Http.Sse.CORS.AllowedOriginsRegex.IfNoMatch)
+	})
+}
 
+func TestCORSConfigInvalidRegex_YAML(t *testing.T) {
+	utils.UseTempFile(`
+http:
+  sse:
+    cors: 
+      enabled: true
+      allowed_origins_regex:
+        patterns:
+          - "*"
+        if_no_match: https://example1.com
+`, func(file string) {
+		_, err := LoadConfigFromFileAndEnvironment(file)
+		require.ErrorContains(t, err, "error parsing regexp: missing argument to repetition operator: `*`")
 	})
 }
 

--- a/config/env.go
+++ b/config/env.go
@@ -170,6 +170,13 @@ func (c *CORSConfig) loadEnv(prefix string) {
 	prefix = concatPrefix(prefix, "CORS")
 	readEnv(prefix, "ENABLED", &c.Enabled, toBool)
 	readEnv(prefix, "ALLOWED_ORIGINS", &c.AllowedOrigins, toStringSlice)
+	c.AllowedOriginsRegex.loadEnv(prefix)
+}
+
+func (o *OriginRegexConfig) loadEnv(prefix string) {
+	prefix = concatPrefix(prefix, "ALLOWED_ORIGINS_REGEX")
+	readEnvString(prefix, "IF_NO_MATCH", &o.IfNoMatch)
+	readEnv(prefix, "PATTERNS", &o.Patterns, toStringSlice)
 }
 
 func (t *TlsConfig) loadEnv(prefix string) {

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -9,77 +9,114 @@ import (
 func TestConfig_Validate(t *testing.T) {
 	t.Run("no envs", func(t *testing.T) {
 		conf := Config{}
+		conf.setDefaults()
 		require.ErrorContains(t, conf.Validate(), "sdk: at least 1 SDK must be configured")
 	})
 	t.Run("missing sdk key", func(t *testing.T) {
 		conf := Config{SDKs: map[string]*SDKConfig{"env1": {}}}
+		conf.setDefaults()
 		require.ErrorContains(t, conf.Validate(), "sdk-env1: SDK key is required")
 	})
 	t.Run("invalid data governance", func(t *testing.T) {
 		conf := Config{SDKs: map[string]*SDKConfig{"env1": {Key: "Key", DataGovernance: "inv"}}}
+		conf.setDefaults()
 		require.ErrorContains(t, conf.Validate(), "sdk-env1: invalid data governance value, it must be 'global' or 'eu'")
 	})
 	t.Run("offline invalid file path", func(t *testing.T) {
 		conf := Config{SDKs: map[string]*SDKConfig{"env1": {Key: "Key", Offline: OfflineConfig{Enabled: true, Local: LocalConfig{FilePath: "nonexisting"}}}}}
+		conf.setDefaults()
 		require.ErrorContains(t, conf.Validate(), "sdk-env1: couldn't find the local file")
 	})
 	t.Run("offline file polling invalid poll interval", func(t *testing.T) {
 		utils.UseTempFile("", func(path string) {
 			conf := Config{SDKs: map[string]*SDKConfig{"env1": {Key: "Key", Offline: OfflineConfig{Enabled: true, Local: LocalConfig{FilePath: path, Polling: true, PollInterval: 0}}}}}
+			conf.setDefaults()
 			require.ErrorContains(t, conf.Validate(), "sdk-env1: local file poll interval must be greater than 1 seconds")
 		})
 	})
 	t.Run("offline enabled without file and cache", func(t *testing.T) {
 		conf := Config{SDKs: map[string]*SDKConfig{"env1": {Key: "Key", Offline: OfflineConfig{Enabled: true}}}}
+		conf.setDefaults()
 		require.ErrorContains(t, conf.Validate(), "sdk-env1: offline mode requires either a configured cache or a local file")
 	})
 	t.Run("offline both local file and cache", func(t *testing.T) {
 		conf := Config{SDKs: map[string]*SDKConfig{"env1": {Key: "Key", Offline: OfflineConfig{Enabled: true, UseCache: true, Local: LocalConfig{FilePath: "file"}}}}}
+		conf.setDefaults()
 		require.ErrorContains(t, conf.Validate(), "sdk-env1: can't use both local file and cache for offline mode")
 	})
 	t.Run("offline cache without redis", func(t *testing.T) {
 		conf := Config{SDKs: map[string]*SDKConfig{"env1": {Key: "Key", Offline: OfflineConfig{Enabled: true, UseCache: true}}}}
+		conf.setDefaults()
 		require.ErrorContains(t, conf.Validate(), "sdk-env1: offline mode enabled with cache, but no cache is configured")
 	})
 	t.Run("offline cache invalid poll interval", func(t *testing.T) {
 		conf := Config{SDKs: map[string]*SDKConfig{"env1": {Key: "Key", Offline: OfflineConfig{Enabled: true, UseCache: true, CachePollInterval: 0}}}, Cache: CacheConfig{Redis: RedisConfig{Enabled: true, Addresses: []string{"localhost"}}}}
+		conf.setDefaults()
 		require.ErrorContains(t, conf.Validate(), "sdk-env1: cache poll interval must be greater than 1 seconds")
 	})
 	t.Run("global offline cache invalid poll interval", func(t *testing.T) {
 		conf := Config{SDKs: map[string]*SDKConfig{"env1": {Key: "Key"}}, Cache: CacheConfig{Redis: RedisConfig{Enabled: true, Addresses: []string{"localhost"}}}, GlobalOfflineConfig: GlobalOfflineConfig{Enabled: true, CachePollInterval: -1}}
+		conf.setDefaults()
 		require.ErrorContains(t, conf.Validate(), "offline: cache poll interval must be greater than 1 seconds")
 	})
 	t.Run("global offline cache without cache", func(t *testing.T) {
 		conf := Config{SDKs: map[string]*SDKConfig{"env1": {Key: "Key"}}, GlobalOfflineConfig: GlobalOfflineConfig{Enabled: true}}
+		conf.setDefaults()
 		require.ErrorContains(t, conf.Validate(), "offline: global offline mode enabled, but no cache is configured")
 	})
 	t.Run("redis enabled without addresses", func(t *testing.T) {
-		conf := Config{SDKs: map[string]*SDKConfig{"env1": {Key: "Key"}}, Cache: CacheConfig{Redis: RedisConfig{Enabled: true}}}
+		conf := Config{SDKs: map[string]*SDKConfig{"env1": {Key: "Key"}}, Cache: CacheConfig{Redis: RedisConfig{Enabled: true}}, Grpc: GrpcConfig{Port: 100}, Metrics: MetricsConfig{Port: 90}, Http: HttpConfig{Port: 80}}
 		require.ErrorContains(t, conf.Validate(), "redis: at least 1 server address required")
 	})
 	t.Run("redis invalid tls config", func(t *testing.T) {
 		conf := Config{SDKs: map[string]*SDKConfig{"env1": {Key: "Key"}}, Cache: CacheConfig{Redis: RedisConfig{Enabled: true, Addresses: []string{"localhost"}, Tls: TlsConfig{Enabled: true, Certificates: []CertConfig{{Key: "key"}}}}}}
+		conf.setDefaults()
 		require.ErrorContains(t, conf.Validate(), "tls: both TLS cert and key file required")
 
 		conf = Config{SDKs: map[string]*SDKConfig{"env1": {Key: "Key"}}, Cache: CacheConfig{Redis: RedisConfig{Enabled: true, Addresses: []string{"localhost"}, Tls: TlsConfig{Enabled: true, Certificates: []CertConfig{{Cert: "cert"}}}}}}
+		conf.setDefaults()
 		require.ErrorContains(t, conf.Validate(), "tls: both TLS cert and key file required")
 	})
 	t.Run("webhook signature invalid validity time", func(t *testing.T) {
 		conf := Config{SDKs: map[string]*SDKConfig{"env1": {Key: "Key", WebhookSigningKey: "key", WebhookSignatureValidFor: 2}}}
+		conf.setDefaults()
 		require.ErrorContains(t, conf.Validate(), "sdk-env1: webhook signature validity check must be greater than 5 seconds")
 	})
 	t.Run("webhook invalid auth", func(t *testing.T) {
 		conf := Config{SDKs: map[string]*SDKConfig{"env1": {Key: "Key"}}, Http: HttpConfig{Webhook: WebhookConfig{Enabled: true, Auth: AuthConfig{User: "user"}}}}
+		conf.setDefaults()
 		require.ErrorContains(t, conf.Validate(), "webhook: both basic auth user and password required")
 
 		conf = Config{SDKs: map[string]*SDKConfig{"env1": {Key: "Key"}}, Http: HttpConfig{Webhook: WebhookConfig{Enabled: true, Auth: AuthConfig{Password: "pass"}}}}
+		conf.setDefaults()
 		require.ErrorContains(t, conf.Validate(), "webhook: both basic auth user and password required")
 	})
 	t.Run("http invalid tls config", func(t *testing.T) {
 		conf := Config{SDKs: map[string]*SDKConfig{"env1": {Key: "Key"}}, Tls: TlsConfig{Enabled: true, Certificates: []CertConfig{{Key: "key"}}}}
+		conf.setDefaults()
 		require.ErrorContains(t, conf.Validate(), "tls: both TLS cert and key file required")
 
 		conf = Config{SDKs: map[string]*SDKConfig{"env1": {Key: "Key"}}, Tls: TlsConfig{Enabled: true, Certificates: []CertConfig{{Cert: "cert"}}}}
+		conf.setDefaults()
 		require.ErrorContains(t, conf.Validate(), "tls: both TLS cert and key file required")
+	})
+	t.Run("invalid ports", func(t *testing.T) {
+		t.Run("http", func(t *testing.T) {
+			conf := Config{SDKs: map[string]*SDKConfig{"env1": {Key: "Key"}}, Http: HttpConfig{Port: -1}}
+			require.ErrorContains(t, conf.Validate(), "http: invalid port -1")
+		})
+		t.Run("metrics", func(t *testing.T) {
+			conf := Config{SDKs: map[string]*SDKConfig{"env1": {Key: "Key"}}, Metrics: MetricsConfig{Port: -1}, Http: HttpConfig{Port: 80}}
+			require.ErrorContains(t, conf.Validate(), "metrics: invalid port -1")
+		})
+		t.Run("grpc", func(t *testing.T) {
+			conf := Config{SDKs: map[string]*SDKConfig{"env1": {Key: "Key"}}, Grpc: GrpcConfig{Port: -1}, Metrics: MetricsConfig{Port: 90}, Http: HttpConfig{Port: 80}}
+			require.ErrorContains(t, conf.Validate(), "grpc: invalid port -1")
+		})
+	})
+	t.Run("cors regex invalid", func(t *testing.T) {
+		conf := Config{SDKs: map[string]*SDKConfig{"env1": {Key: "Key"}}, Http: HttpConfig{Api: ApiConfig{Enabled: true, CORS: CORSConfig{Enabled: true, AllowedOriginsRegex: OriginRegexConfig{Patterns: []string{"*"}}}}}}
+		conf.setDefaults()
+		require.ErrorContains(t, conf.Validate(), "cors: the 'if no watch' field is required when allowed origins regex is set")
 	})
 }

--- a/web/mware/cors.go
+++ b/web/mware/cors.go
@@ -1,6 +1,7 @@
 package mware
 
 import (
+	"github.com/configcat/configcat-proxy/config"
 	"net/http"
 	"slices"
 	"strings"
@@ -23,25 +24,25 @@ var defaultExposedHeaders = strings.Join([]string{
 
 var defaultAllowedOrigin = "*"
 
-func CORS(allowedMethods []string, allowedOrigins []string, next http.HandlerFunc) http.HandlerFunc {
+func CORS(allowedMethods []string, allowedOrigins []string, originRegexConfig *config.OriginRegexConfig, next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		origin := r.Header.Get("Origin")
 		if r.Method == http.MethodOptions {
-			setOptionsCORSHeaders(w, origin, allowedOrigins, allowedMethods)
+			setOptionsCORSHeaders(w, origin, allowedOrigins, originRegexConfig, allowedMethods)
 		} else {
-			setDefaultCORSHeaders(w, origin, allowedOrigins)
+			setDefaultCORSHeaders(w, origin, allowedOrigins, originRegexConfig)
 		}
 		next(w, r)
 	}
 }
 
-func setDefaultCORSHeaders(w http.ResponseWriter, requestOrigin string, allowedOrigins []string) {
-	w.Header().Set("Access-Control-Allow-Origin", determineOrigin(requestOrigin, allowedOrigins))
+func setDefaultCORSHeaders(w http.ResponseWriter, requestOrigin string, allowedOrigins []string, originRegexConfig *config.OriginRegexConfig) {
+	w.Header().Set("Access-Control-Allow-Origin", determineOrigin(requestOrigin, allowedOrigins, originRegexConfig))
 	w.Header().Set("Access-Control-Expose-Headers", defaultExposedHeaders)
 }
 
-func setOptionsCORSHeaders(w http.ResponseWriter, requestOrigin string, allowedOrigins []string, allowedMethods []string) {
-	setDefaultCORSHeaders(w, requestOrigin, allowedOrigins)
+func setOptionsCORSHeaders(w http.ResponseWriter, requestOrigin string, allowedOrigins []string, originRegexConfig *config.OriginRegexConfig, allowedMethods []string) {
+	setDefaultCORSHeaders(w, requestOrigin, allowedOrigins, originRegexConfig)
 	w.Header().Set("Access-Control-Allow-Credentials", "false")
 	w.Header().Set("Access-Control-Max-Age", "600")
 	w.Header().Set("Access-Control-Allow-Headers", defaultAllowedHeaders)
@@ -50,16 +51,29 @@ func setOptionsCORSHeaders(w http.ResponseWriter, requestOrigin string, allowedO
 	}
 }
 
-func determineOrigin(requestOrigin string, allowedOrigins []string) string {
-	if allowedOrigins != nil && len(allowedOrigins) > 0 {
+func determineOrigin(requestOrigin string, allowedOrigins []string, originRegexConfig *config.OriginRegexConfig) string {
+	defaultResult := defaultAllowedOrigin
+
+	hasAllowedOriginsSet := allowedOrigins != nil && len(allowedOrigins) > 0
+	hasOriginRegexSet := originRegexConfig != nil && originRegexConfig.Regexes != nil && len(originRegexConfig.Regexes) > 0
+
+	if hasAllowedOriginsSet {
 		if slices.Contains(allowedOrigins, requestOrigin) {
 			return requestOrigin
 		} else {
-			return allowedOrigins[0]
+			defaultResult = allowedOrigins[0]
 		}
 	}
-	if requestOrigin != "" {
+	if hasOriginRegexSet {
+		for _, regex := range originRegexConfig.Regexes {
+			if regex.MatchString(requestOrigin) {
+				return requestOrigin
+			}
+		}
+		defaultResult = originRegexConfig.IfNoMatch
+	}
+	if !hasAllowedOriginsSet && !hasOriginRegexSet && requestOrigin != "" {
 		return requestOrigin
 	}
-	return defaultAllowedOrigin
+	return defaultResult
 }

--- a/web/mware/cors_test.go
+++ b/web/mware/cors_test.go
@@ -1,15 +1,19 @@
 package mware
 
 import (
+	"github.com/configcat/configcat-proxy/config"
+	"github.com/configcat/configcat-proxy/internal/utils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"testing"
 )
 
 func TestCORS(t *testing.T) {
 	t.Run("* origin, options", func(t *testing.T) {
-		handler := CORS([]string{http.MethodGet, http.MethodOptions}, nil, func(writer http.ResponseWriter, request *http.Request) {
+		handler := CORS([]string{http.MethodGet, http.MethodOptions}, nil, nil, func(writer http.ResponseWriter, request *http.Request) {
 			writer.WriteHeader(http.StatusOK)
 		})
 		srv := httptest.NewServer(handler)
@@ -26,7 +30,7 @@ func TestCORS(t *testing.T) {
 		assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding", resp.Header.Get("Access-Control-Expose-Headers"))
 	})
 	t.Run("custom origin, options", func(t *testing.T) {
-		handler := CORS([]string{http.MethodGet, http.MethodOptions}, []string{"http://localhost"}, func(writer http.ResponseWriter, request *http.Request) {
+		handler := CORS([]string{http.MethodGet, http.MethodOptions}, []string{"http://localhost"}, nil, func(writer http.ResponseWriter, request *http.Request) {
 			writer.WriteHeader(http.StatusOK)
 		})
 		srv := httptest.NewServer(handler)
@@ -44,7 +48,7 @@ func TestCORS(t *testing.T) {
 		assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding", resp.Header.Get("Access-Control-Expose-Headers"))
 	})
 	t.Run("* origin, get", func(t *testing.T) {
-		handler := CORS([]string{http.MethodGet, http.MethodOptions}, nil, func(writer http.ResponseWriter, request *http.Request) {
+		handler := CORS([]string{http.MethodGet, http.MethodOptions}, nil, nil, func(writer http.ResponseWriter, request *http.Request) {
 			writer.WriteHeader(http.StatusOK)
 		})
 		srv := httptest.NewServer(handler)
@@ -57,7 +61,7 @@ func TestCORS(t *testing.T) {
 		assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding", resp.Header.Get("Access-Control-Expose-Headers"))
 	})
 	t.Run("custom origin, get", func(t *testing.T) {
-		handler := CORS([]string{http.MethodGet, http.MethodOptions}, []string{"http://localhost"}, func(writer http.ResponseWriter, request *http.Request) {
+		handler := CORS([]string{http.MethodGet, http.MethodOptions}, []string{"http://localhost"}, nil, func(writer http.ResponseWriter, request *http.Request) {
 			writer.WriteHeader(http.StatusOK)
 		})
 		srv := httptest.NewServer(handler)
@@ -71,7 +75,7 @@ func TestCORS(t *testing.T) {
 		assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding", resp.Header.Get("Access-Control-Expose-Headers"))
 	})
 	t.Run("custom origin, options, multiple origins", func(t *testing.T) {
-		handler := CORS([]string{http.MethodGet, http.MethodOptions}, []string{"https://test1.com", "https://test2.com"}, func(writer http.ResponseWriter, request *http.Request) {
+		handler := CORS([]string{http.MethodGet, http.MethodOptions}, []string{"https://test1.com", "https://test2.com"}, nil, func(writer http.ResponseWriter, request *http.Request) {
 			writer.WriteHeader(http.StatusOK)
 		})
 		srv := httptest.NewServer(handler)
@@ -121,7 +125,7 @@ func TestCORS(t *testing.T) {
 		assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding", resp.Header.Get("Access-Control-Expose-Headers"))
 	})
 	t.Run("custom origin, get, multiple origins", func(t *testing.T) {
-		handler := CORS([]string{http.MethodGet, http.MethodOptions}, []string{"https://test1.com", "https://test2.com"}, func(writer http.ResponseWriter, request *http.Request) {
+		handler := CORS([]string{http.MethodGet, http.MethodOptions}, []string{"https://test1.com", "https://test2.com"}, nil, func(writer http.ResponseWriter, request *http.Request) {
 			writer.WriteHeader(http.StatusOK)
 		})
 		srv := httptest.NewServer(handler)
@@ -153,5 +157,146 @@ func TestCORS(t *testing.T) {
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		assert.Equal(t, "https://test1.com", resp.Header.Get("Access-Control-Allow-Origin"))
 		assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding", resp.Header.Get("Access-Control-Expose-Headers"))
+	})
+	t.Run("custom origin, get, regex", func(t *testing.T) {
+		regex1, _ := regexp.Compile(".*test1\\.com")
+		regex2, _ := regexp.Compile(".*test2\\.com")
+		t.Run("only regex", func(t *testing.T) {
+			handler := CORS([]string{http.MethodGet, http.MethodOptions}, nil, &config.OriginRegexConfig{
+				Regexes: []*regexp.Regexp{
+					regex1,
+					regex2,
+				},
+				IfNoMatch: "https://test3.com",
+			}, func(writer http.ResponseWriter, request *http.Request) {
+				writer.WriteHeader(http.StatusOK)
+			})
+			srv := httptest.NewServer(handler)
+			client := http.Client{}
+
+			req, _ := http.NewRequest(http.MethodGet, srv.URL, http.NoBody)
+			req.Header.Set("Origin", "https://test1.com")
+			resp, _ := client.Do(req)
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			assert.Equal(t, "https://test1.com", resp.Header.Get("Access-Control-Allow-Origin"))
+
+			req, _ = http.NewRequest(http.MethodGet, srv.URL, http.NoBody)
+			req.Header.Set("Origin", "https://sub1.test1.com")
+			resp, _ = client.Do(req)
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			assert.Equal(t, "https://sub1.test1.com", resp.Header.Get("Access-Control-Allow-Origin"))
+
+			req, _ = http.NewRequest(http.MethodGet, srv.URL, http.NoBody)
+			req.Header.Set("Origin", "https://sub1.test2.com")
+			resp, _ = client.Do(req)
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			assert.Equal(t, "https://sub1.test2.com", resp.Header.Get("Access-Control-Allow-Origin"))
+
+			req, _ = http.NewRequest(http.MethodGet, srv.URL, http.NoBody)
+			req.Header.Set("Origin", "https://sub1.someelse.com")
+			resp, _ = client.Do(req)
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			assert.Equal(t, "https://test3.com", resp.Header.Get("Access-Control-Allow-Origin"))
+		})
+		t.Run("both", func(t *testing.T) {
+			handler := CORS([]string{http.MethodGet, http.MethodOptions}, []string{"https://test3.com", "https://test4.com"}, &config.OriginRegexConfig{
+				Regexes: []*regexp.Regexp{
+					regex1,
+					regex2,
+				},
+				IfNoMatch: "https://test5.com",
+			}, func(writer http.ResponseWriter, request *http.Request) {
+				writer.WriteHeader(http.StatusOK)
+			})
+			srv := httptest.NewServer(handler)
+			client := http.Client{}
+
+			req, _ := http.NewRequest(http.MethodGet, srv.URL, http.NoBody)
+			req.Header.Set("Origin", "https://test1.com")
+			resp, _ := client.Do(req)
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			assert.Equal(t, "https://test1.com", resp.Header.Get("Access-Control-Allow-Origin"))
+
+			req, _ = http.NewRequest(http.MethodGet, srv.URL, http.NoBody)
+			req.Header.Set("Origin", "https://sub1.test1.com")
+			resp, _ = client.Do(req)
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			assert.Equal(t, "https://sub1.test1.com", resp.Header.Get("Access-Control-Allow-Origin"))
+
+			req, _ = http.NewRequest(http.MethodGet, srv.URL, http.NoBody)
+			req.Header.Set("Origin", "https://sub1.test2.com")
+			resp, _ = client.Do(req)
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			assert.Equal(t, "https://sub1.test2.com", resp.Header.Get("Access-Control-Allow-Origin"))
+
+			req, _ = http.NewRequest(http.MethodGet, srv.URL, http.NoBody)
+			req.Header.Set("Origin", "https://test3.com")
+			resp, _ = client.Do(req)
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			assert.Equal(t, "https://test3.com", resp.Header.Get("Access-Control-Allow-Origin"))
+
+			req, _ = http.NewRequest(http.MethodGet, srv.URL, http.NoBody)
+			req.Header.Set("Origin", "https://test4.com")
+			resp, _ = client.Do(req)
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			assert.Equal(t, "https://test4.com", resp.Header.Get("Access-Control-Allow-Origin"))
+
+			req, _ = http.NewRequest(http.MethodGet, srv.URL, http.NoBody)
+			req.Header.Set("Origin", "https://sub1.someelse.com")
+			resp, _ = client.Do(req)
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			assert.Equal(t, "https://test5.com", resp.Header.Get("Access-Control-Allow-Origin"))
+
+			req, _ = http.NewRequest(http.MethodGet, srv.URL, http.NoBody)
+			resp, _ = client.Do(req)
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			assert.Equal(t, "https://test5.com", resp.Header.Get("Access-Control-Allow-Origin"))
+		})
+	})
+	t.Run("custom origin, get, from config", func(t *testing.T) {
+		utils.UseTempFile(`
+http:
+  api:
+    cors: 
+      enabled: true
+      allowed_origins_regex:
+        patterns:
+          - .*test1\.com
+          - .*test2\.com
+        if_no_match: https://test3.com
+`, func(file string) {
+			conf, err := config.LoadConfigFromFileAndEnvironment(file)
+			require.NoError(t, err)
+
+			handler := CORS([]string{http.MethodGet, http.MethodOptions}, conf.Http.Api.CORS.AllowedOrigins, &conf.Http.Api.CORS.AllowedOriginsRegex, func(writer http.ResponseWriter, request *http.Request) {
+				writer.WriteHeader(http.StatusOK)
+			})
+			srv := httptest.NewServer(handler)
+			client := http.Client{}
+
+			req, _ := http.NewRequest(http.MethodGet, srv.URL, http.NoBody)
+			req.Header.Set("Origin", "https://test1.com")
+			resp, _ := client.Do(req)
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			assert.Equal(t, "https://test1.com", resp.Header.Get("Access-Control-Allow-Origin"))
+
+			req, _ = http.NewRequest(http.MethodGet, srv.URL, http.NoBody)
+			req.Header.Set("Origin", "https://sub1.test1.com")
+			resp, _ = client.Do(req)
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			assert.Equal(t, "https://sub1.test1.com", resp.Header.Get("Access-Control-Allow-Origin"))
+
+			req, _ = http.NewRequest(http.MethodGet, srv.URL, http.NoBody)
+			req.Header.Set("Origin", "https://sub1.test2.com")
+			resp, _ = client.Do(req)
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			assert.Equal(t, "https://sub1.test2.com", resp.Header.Get("Access-Control-Allow-Origin"))
+
+			req, _ = http.NewRequest(http.MethodGet, srv.URL, http.NoBody)
+			req.Header.Set("Origin", "https://sub1.someelse.com")
+			resp, _ = client.Do(req)
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+			assert.Equal(t, "https://test3.com", resp.Header.Get("Access-Control-Allow-Origin"))
+		})
 	})
 }

--- a/web/router.go
+++ b/web/router.go
@@ -74,7 +74,7 @@ func (s *HttpRouter) setupSSERoutes(conf *config.SseConfig, sdkClients map[strin
 			endpoint.handler = mware.ExtraHeaders(conf.Headers, endpoint.handler)
 		}
 		if conf.CORS.Enabled {
-			endpoint.handler = mware.CORS([]string{endpoint.method, http.MethodOptions}, conf.CORS.AllowedOrigins, endpoint.handler)
+			endpoint.handler = mware.CORS([]string{endpoint.method, http.MethodOptions}, conf.CORS.AllowedOrigins, &conf.CORS.AllowedOriginsRegex, endpoint.handler)
 		}
 		if l.Level() == log.Debug {
 			endpoint.handler = mware.DebugLog(l, endpoint.handler)
@@ -114,7 +114,7 @@ func (s *HttpRouter) setupCDNProxyRoutes(conf *config.CdnProxyConfig, sdkClients
 		handler = mware.ExtraHeaders(conf.Headers, handler)
 	}
 	if conf.CORS.Enabled {
-		handler = mware.CORS([]string{http.MethodGet, http.MethodOptions}, conf.CORS.AllowedOrigins, handler)
+		handler = mware.CORS([]string{http.MethodGet, http.MethodOptions}, conf.CORS.AllowedOrigins, &conf.CORS.AllowedOriginsRegex, handler)
 	}
 	if s.metrics != nil {
 		handler = metrics.Measure(s.metrics, handler)
@@ -161,7 +161,7 @@ func (s *HttpRouter) setupAPIRoutes(conf *config.ApiConfig, sdkClients map[strin
 			endpoint.handler = mware.ExtraHeaders(conf.Headers, endpoint.handler)
 		}
 		if conf.CORS.Enabled {
-			endpoint.handler = mware.CORS([]string{endpoint.method, http.MethodOptions}, conf.CORS.AllowedOrigins, endpoint.handler)
+			endpoint.handler = mware.CORS([]string{endpoint.method, http.MethodOptions}, conf.CORS.AllowedOrigins, &conf.CORS.AllowedOriginsRegex, endpoint.handler)
 		}
 		if s.metrics != nil {
 			endpoint.handler = metrics.Measure(s.metrics, endpoint.handler)


### PR DESCRIPTION
### Describe the purpose of your pull request

This PR adds the functionality to define regex patterns for CORS allowed origins.

Example:
```yaml
http:
  api:
    cors: 
      enabled: true
      allowed_origins_regex:
        patterns:
          - .*\.example1\.com
          - .*\.example2\.com
        if_no_match: https://example1.com
```

The `if_no_match` field is mandatory when the regex option is set because that value is used in the `Access-Control-Allow-Origin` header when an incoming request's origin doesn't match with any configured patterns.

If both `allowed_origins_regex` and `allowed_origins` options are set, the list in `allowed_origins` will be checked first and if there isn't a match, the execution will jump to evaluate the regex patterns.

### Related issues (only if applicable)

n/a

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
