### PR TITLE
Auto put auth headers into CORS allowed headers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/yuin/gopher-lua v1.1.0 // indirect
 	golang.org/x/net v0.17.0 // indirect
-	golang.org/x/sys v0.13.0 // indirect
+	golang.org/x/sys v0.14.0 // indirect
 	golang.org/x/text v0.13.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231009173412-8bfb1ae86b6c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,8 @@ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20190204203706-41f3e6584952/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
-golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.14.0 h1:Vz7Qs629MkJkGyHxUlRHizWJRG2j8fbQKjELVSNhy7Q=
+golang.org/x/sys v0.14.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/text v0.13.0 h1:ablQoSUd0tRdKxZewP80B+BaqeKJuVhuRxj/dkrun3k=
 golang.org/x/text v0.13.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -77,3 +77,23 @@ func AddSdkIdContextParam(r *http.Request) {
 	ctx := context.WithValue(context.Background(), httprouter.ParamsKey, params)
 	*r = *r.WithContext(ctx)
 }
+
+func Keys[M ~map[K]V, K comparable, V any](m M) []K {
+	r := make([]K, 0, len(m))
+	for k := range m {
+		r = append(r, k)
+	}
+	return r
+}
+
+func DedupStringSlice[T string](strings []T) []T {
+	keys := make(map[T]bool)
+	var list []T
+	for _, item := range strings {
+		if _, value := keys[item]; !value {
+			keys[item] = true
+			list = append(list, item)
+		}
+	}
+	return list
+}

--- a/sdk/user_agent.go
+++ b/sdk/user_agent.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 )
 
-const proxyVersion = "0.2.2"
+const proxyVersion = "0.2.3"
 
 type userAgentInterceptor struct {
 	http.RoundTripper

--- a/web/mware/cors_test.go
+++ b/web/mware/cors_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestCORS(t *testing.T) {
 	t.Run("* origin, options", func(t *testing.T) {
-		handler := CORS([]string{http.MethodGet, http.MethodOptions}, nil, nil, func(writer http.ResponseWriter, request *http.Request) {
+		handler := CORS([]string{http.MethodGet, http.MethodOptions}, nil, nil, nil, nil, func(writer http.ResponseWriter, request *http.Request) {
 			writer.WriteHeader(http.StatusOK)
 		})
 		srv := httptest.NewServer(handler)
@@ -30,7 +30,7 @@ func TestCORS(t *testing.T) {
 		assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding", resp.Header.Get("Access-Control-Expose-Headers"))
 	})
 	t.Run("custom origin, options", func(t *testing.T) {
-		handler := CORS([]string{http.MethodGet, http.MethodOptions}, []string{"http://localhost"}, nil, func(writer http.ResponseWriter, request *http.Request) {
+		handler := CORS([]string{http.MethodGet, http.MethodOptions}, []string{"http://localhost"}, nil, nil, nil, func(writer http.ResponseWriter, request *http.Request) {
 			writer.WriteHeader(http.StatusOK)
 		})
 		srv := httptest.NewServer(handler)
@@ -48,7 +48,7 @@ func TestCORS(t *testing.T) {
 		assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding", resp.Header.Get("Access-Control-Expose-Headers"))
 	})
 	t.Run("* origin, get", func(t *testing.T) {
-		handler := CORS([]string{http.MethodGet, http.MethodOptions}, nil, nil, func(writer http.ResponseWriter, request *http.Request) {
+		handler := CORS([]string{http.MethodGet, http.MethodOptions}, nil, nil, nil, nil, func(writer http.ResponseWriter, request *http.Request) {
 			writer.WriteHeader(http.StatusOK)
 		})
 		srv := httptest.NewServer(handler)
@@ -61,7 +61,7 @@ func TestCORS(t *testing.T) {
 		assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding", resp.Header.Get("Access-Control-Expose-Headers"))
 	})
 	t.Run("custom origin, get", func(t *testing.T) {
-		handler := CORS([]string{http.MethodGet, http.MethodOptions}, []string{"http://localhost"}, nil, func(writer http.ResponseWriter, request *http.Request) {
+		handler := CORS([]string{http.MethodGet, http.MethodOptions}, []string{"http://localhost"}, nil, nil, nil, func(writer http.ResponseWriter, request *http.Request) {
 			writer.WriteHeader(http.StatusOK)
 		})
 		srv := httptest.NewServer(handler)
@@ -75,7 +75,7 @@ func TestCORS(t *testing.T) {
 		assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding", resp.Header.Get("Access-Control-Expose-Headers"))
 	})
 	t.Run("custom origin, options, multiple origins", func(t *testing.T) {
-		handler := CORS([]string{http.MethodGet, http.MethodOptions}, []string{"https://test1.com", "https://test2.com"}, nil, func(writer http.ResponseWriter, request *http.Request) {
+		handler := CORS([]string{http.MethodGet, http.MethodOptions}, []string{"https://test1.com", "https://test2.com"}, []string{"h1", "ETag"}, []string{"X-AUTH"}, nil, func(writer http.ResponseWriter, request *http.Request) {
 			writer.WriteHeader(http.StatusOK)
 		})
 		srv := httptest.NewServer(handler)
@@ -87,10 +87,10 @@ func TestCORS(t *testing.T) {
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		assert.Equal(t, "GET,OPTIONS", resp.Header.Get("Access-Control-Allow-Methods"))
 		assert.Equal(t, "false", resp.Header.Get("Access-Control-Allow-Credentials"))
-		assert.Equal(t, "Cache-Control,Content-Type,Content-Length,Accept-Encoding,If-None-Match", resp.Header.Get("Access-Control-Allow-Headers"))
+		assert.Equal(t, "Cache-Control,Content-Type,Content-Length,Accept-Encoding,If-None-Match,X-AUTH", resp.Header.Get("Access-Control-Allow-Headers"))
 		assert.Equal(t, "600", resp.Header.Get("Access-Control-Max-Age"))
 		assert.Equal(t, "https://test1.com", resp.Header.Get("Access-Control-Allow-Origin"))
-		assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding", resp.Header.Get("Access-Control-Expose-Headers"))
+		assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding,h1", resp.Header.Get("Access-Control-Expose-Headers"))
 
 		req, _ = http.NewRequest(http.MethodOptions, srv.URL, http.NoBody)
 		req.Header.Set("Origin", "https://test2.com")
@@ -98,10 +98,10 @@ func TestCORS(t *testing.T) {
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		assert.Equal(t, "GET,OPTIONS", resp.Header.Get("Access-Control-Allow-Methods"))
 		assert.Equal(t, "false", resp.Header.Get("Access-Control-Allow-Credentials"))
-		assert.Equal(t, "Cache-Control,Content-Type,Content-Length,Accept-Encoding,If-None-Match", resp.Header.Get("Access-Control-Allow-Headers"))
+		assert.Equal(t, "Cache-Control,Content-Type,Content-Length,Accept-Encoding,If-None-Match,X-AUTH", resp.Header.Get("Access-Control-Allow-Headers"))
 		assert.Equal(t, "600", resp.Header.Get("Access-Control-Max-Age"))
 		assert.Equal(t, "https://test2.com", resp.Header.Get("Access-Control-Allow-Origin"))
-		assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding", resp.Header.Get("Access-Control-Expose-Headers"))
+		assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding,h1", resp.Header.Get("Access-Control-Expose-Headers"))
 
 		req, _ = http.NewRequest(http.MethodOptions, srv.URL, http.NoBody)
 		req.Header.Set("Origin", "something-else")
@@ -109,23 +109,23 @@ func TestCORS(t *testing.T) {
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		assert.Equal(t, "GET,OPTIONS", resp.Header.Get("Access-Control-Allow-Methods"))
 		assert.Equal(t, "false", resp.Header.Get("Access-Control-Allow-Credentials"))
-		assert.Equal(t, "Cache-Control,Content-Type,Content-Length,Accept-Encoding,If-None-Match", resp.Header.Get("Access-Control-Allow-Headers"))
+		assert.Equal(t, "Cache-Control,Content-Type,Content-Length,Accept-Encoding,If-None-Match,X-AUTH", resp.Header.Get("Access-Control-Allow-Headers"))
 		assert.Equal(t, "600", resp.Header.Get("Access-Control-Max-Age"))
 		assert.Equal(t, "https://test1.com", resp.Header.Get("Access-Control-Allow-Origin"))
-		assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding", resp.Header.Get("Access-Control-Expose-Headers"))
+		assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding,h1", resp.Header.Get("Access-Control-Expose-Headers"))
 
 		req, _ = http.NewRequest(http.MethodOptions, srv.URL, http.NoBody)
 		resp, _ = client.Do(req)
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		assert.Equal(t, "GET,OPTIONS", resp.Header.Get("Access-Control-Allow-Methods"))
 		assert.Equal(t, "false", resp.Header.Get("Access-Control-Allow-Credentials"))
-		assert.Equal(t, "Cache-Control,Content-Type,Content-Length,Accept-Encoding,If-None-Match", resp.Header.Get("Access-Control-Allow-Headers"))
+		assert.Equal(t, "Cache-Control,Content-Type,Content-Length,Accept-Encoding,If-None-Match,X-AUTH", resp.Header.Get("Access-Control-Allow-Headers"))
 		assert.Equal(t, "600", resp.Header.Get("Access-Control-Max-Age"))
 		assert.Equal(t, "https://test1.com", resp.Header.Get("Access-Control-Allow-Origin"))
-		assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding", resp.Header.Get("Access-Control-Expose-Headers"))
+		assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding,h1", resp.Header.Get("Access-Control-Expose-Headers"))
 	})
 	t.Run("custom origin, get, multiple origins", func(t *testing.T) {
-		handler := CORS([]string{http.MethodGet, http.MethodOptions}, []string{"https://test1.com", "https://test2.com"}, nil, func(writer http.ResponseWriter, request *http.Request) {
+		handler := CORS([]string{http.MethodGet, http.MethodOptions}, []string{"https://test1.com", "https://test2.com"}, nil, nil, nil, func(writer http.ResponseWriter, request *http.Request) {
 			writer.WriteHeader(http.StatusOK)
 		})
 		srv := httptest.NewServer(handler)
@@ -162,7 +162,7 @@ func TestCORS(t *testing.T) {
 		regex1, _ := regexp.Compile(".*test1\\.com")
 		regex2, _ := regexp.Compile(".*test2\\.com")
 		t.Run("only regex", func(t *testing.T) {
-			handler := CORS([]string{http.MethodGet, http.MethodOptions}, nil, &config.OriginRegexConfig{
+			handler := CORS([]string{http.MethodGet, http.MethodOptions}, nil, nil, nil, &config.OriginRegexConfig{
 				Regexes: []*regexp.Regexp{
 					regex1,
 					regex2,
@@ -199,7 +199,7 @@ func TestCORS(t *testing.T) {
 			assert.Equal(t, "https://test3.com", resp.Header.Get("Access-Control-Allow-Origin"))
 		})
 		t.Run("both", func(t *testing.T) {
-			handler := CORS([]string{http.MethodGet, http.MethodOptions}, []string{"https://test3.com", "https://test4.com"}, &config.OriginRegexConfig{
+			handler := CORS([]string{http.MethodGet, http.MethodOptions}, []string{"https://test3.com", "https://test4.com"}, nil, nil, &config.OriginRegexConfig{
 				Regexes: []*regexp.Regexp{
 					regex1,
 					regex2,
@@ -268,7 +268,7 @@ http:
 			conf, err := config.LoadConfigFromFileAndEnvironment(file)
 			require.NoError(t, err)
 
-			handler := CORS([]string{http.MethodGet, http.MethodOptions}, conf.Http.Api.CORS.AllowedOrigins, &conf.Http.Api.CORS.AllowedOriginsRegex, func(writer http.ResponseWriter, request *http.Request) {
+			handler := CORS([]string{http.MethodGet, http.MethodOptions}, conf.Http.Api.CORS.AllowedOrigins, nil, nil, &conf.Http.Api.CORS.AllowedOriginsRegex, func(writer http.ResponseWriter, request *http.Request) {
 				writer.WriteHeader(http.StatusOK)
 			})
 			srv := httptest.NewServer(handler)

--- a/web/router.go
+++ b/web/router.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"github.com/configcat/configcat-proxy/config"
+	"github.com/configcat/configcat-proxy/internal/utils"
 	"github.com/configcat/configcat-proxy/log"
 	"github.com/configcat/configcat-proxy/metrics"
 	"github.com/configcat/configcat-proxy/sdk"
@@ -74,7 +75,7 @@ func (s *HttpRouter) setupSSERoutes(conf *config.SseConfig, sdkClients map[strin
 			endpoint.handler = mware.ExtraHeaders(conf.Headers, endpoint.handler)
 		}
 		if conf.CORS.Enabled {
-			endpoint.handler = mware.CORS([]string{endpoint.method, http.MethodOptions}, conf.CORS.AllowedOrigins, &conf.CORS.AllowedOriginsRegex, endpoint.handler)
+			endpoint.handler = mware.CORS([]string{endpoint.method, http.MethodOptions}, conf.CORS.AllowedOrigins, utils.Keys(conf.Headers), nil, &conf.CORS.AllowedOriginsRegex, endpoint.handler)
 		}
 		if l.Level() == log.Debug {
 			endpoint.handler = mware.DebugLog(l, endpoint.handler)
@@ -114,7 +115,7 @@ func (s *HttpRouter) setupCDNProxyRoutes(conf *config.CdnProxyConfig, sdkClients
 		handler = mware.ExtraHeaders(conf.Headers, handler)
 	}
 	if conf.CORS.Enabled {
-		handler = mware.CORS([]string{http.MethodGet, http.MethodOptions}, conf.CORS.AllowedOrigins, &conf.CORS.AllowedOriginsRegex, handler)
+		handler = mware.CORS([]string{http.MethodGet, http.MethodOptions}, conf.CORS.AllowedOrigins, utils.Keys(conf.Headers), nil, &conf.CORS.AllowedOriginsRegex, handler)
 	}
 	if s.metrics != nil {
 		handler = metrics.Measure(s.metrics, handler)
@@ -161,7 +162,7 @@ func (s *HttpRouter) setupAPIRoutes(conf *config.ApiConfig, sdkClients map[strin
 			endpoint.handler = mware.ExtraHeaders(conf.Headers, endpoint.handler)
 		}
 		if conf.CORS.Enabled {
-			endpoint.handler = mware.CORS([]string{endpoint.method, http.MethodOptions}, conf.CORS.AllowedOrigins, &conf.CORS.AllowedOriginsRegex, endpoint.handler)
+			endpoint.handler = mware.CORS([]string{endpoint.method, http.MethodOptions}, conf.CORS.AllowedOrigins, utils.Keys(conf.Headers), utils.Keys(conf.AuthHeaders), &conf.CORS.AllowedOriginsRegex, endpoint.handler)
 		}
 		if s.metrics != nil {
 			endpoint.handler = metrics.Measure(s.metrics, endpoint.handler)

--- a/web/router_api_test.go
+++ b/web/router_api_test.go
@@ -29,10 +29,10 @@ func TestAPI_Eval(t *testing.T) {
 
 		assert.Equal(t, "POST,OPTIONS", resp.Header.Get("Access-Control-Allow-Methods"))
 		assert.Equal(t, "false", resp.Header.Get("Access-Control-Allow-Credentials"))
-		assert.Equal(t, "Cache-Control,Content-Type,Content-Length,Accept-Encoding,If-None-Match", resp.Header.Get("Access-Control-Allow-Headers"))
+		assert.Equal(t, "Cache-Control,Content-Type,Content-Length,Accept-Encoding,If-None-Match,X-AUTH", resp.Header.Get("Access-Control-Allow-Headers"))
 		assert.Equal(t, "600", resp.Header.Get("Access-Control-Max-Age"))
 		assert.Equal(t, "*", resp.Header.Get("Access-Control-Allow-Origin"))
-		assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding", resp.Header.Get("Access-Control-Expose-Headers"))
+		assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding,h1", resp.Header.Get("Access-Control-Expose-Headers"))
 		assert.Equal(t, "v1", resp.Header.Get("h1"))
 	})
 	t.Run("missing auth", func(t *testing.T) {
@@ -40,7 +40,7 @@ func TestAPI_Eval(t *testing.T) {
 		resp, _ := client.Do(req)
 		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 		assert.Equal(t, "*", resp.Header.Get("Access-Control-Allow-Origin"))
-		assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding", resp.Header.Get("Access-Control-Expose-Headers"))
+		assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding,h1", resp.Header.Get("Access-Control-Expose-Headers"))
 		assert.Equal(t, "v1", resp.Header.Get("h1"))
 	})
 	t.Run("ok", func(t *testing.T) {
@@ -52,7 +52,7 @@ func TestAPI_Eval(t *testing.T) {
 		_ = resp.Body.Close()
 		assert.Equal(t, `{"value":true,"variationId":"v_flag"}`, string(body))
 		assert.Equal(t, "*", resp.Header.Get("Access-Control-Allow-Origin"))
-		assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding", resp.Header.Get("Access-Control-Expose-Headers"))
+		assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding,h1", resp.Header.Get("Access-Control-Expose-Headers"))
 		assert.Equal(t, "v1", resp.Header.Get("h1"))
 	})
 	t.Run("ok gzip", func(t *testing.T) {
@@ -70,7 +70,7 @@ func TestAPI_Eval(t *testing.T) {
 		_ = wr.Flush()
 		assert.Equal(t, buf.Bytes(), body)
 		assert.Equal(t, "*", resp.Header.Get("Access-Control-Allow-Origin"))
-		assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding", resp.Header.Get("Access-Control-Expose-Headers"))
+		assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding,h1", resp.Header.Get("Access-Control-Expose-Headers"))
 		assert.Equal(t, "v1", resp.Header.Get("h1"))
 	})
 	t.Run("get not allowed", func(t *testing.T) {
@@ -140,10 +140,10 @@ func TestAPI_EvalAll(t *testing.T) {
 
 		assert.Equal(t, "POST,OPTIONS", resp.Header.Get("Access-Control-Allow-Methods"))
 		assert.Equal(t, "false", resp.Header.Get("Access-Control-Allow-Credentials"))
-		assert.Equal(t, "Cache-Control,Content-Type,Content-Length,Accept-Encoding,If-None-Match", resp.Header.Get("Access-Control-Allow-Headers"))
+		assert.Equal(t, "Cache-Control,Content-Type,Content-Length,Accept-Encoding,If-None-Match,X-AUTH", resp.Header.Get("Access-Control-Allow-Headers"))
 		assert.Equal(t, "600", resp.Header.Get("Access-Control-Max-Age"))
 		assert.Equal(t, "*", resp.Header.Get("Access-Control-Allow-Origin"))
-		assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding", resp.Header.Get("Access-Control-Expose-Headers"))
+		assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding,h1", resp.Header.Get("Access-Control-Expose-Headers"))
 		assert.Equal(t, "v1", resp.Header.Get("h1"))
 	})
 	t.Run("missing auth", func(t *testing.T) {
@@ -151,7 +151,7 @@ func TestAPI_EvalAll(t *testing.T) {
 		resp, _ := client.Do(req)
 		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 		assert.Equal(t, "*", resp.Header.Get("Access-Control-Allow-Origin"))
-		assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding", resp.Header.Get("Access-Control-Expose-Headers"))
+		assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding,h1", resp.Header.Get("Access-Control-Expose-Headers"))
 		assert.Equal(t, "v1", resp.Header.Get("h1"))
 	})
 	t.Run("ok", func(t *testing.T) {
@@ -163,7 +163,7 @@ func TestAPI_EvalAll(t *testing.T) {
 		_ = resp.Body.Close()
 		assert.Equal(t, `{"flag":{"value":true,"variationId":"v_flag"}}`, string(body))
 		assert.Equal(t, "*", resp.Header.Get("Access-Control-Allow-Origin"))
-		assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding", resp.Header.Get("Access-Control-Expose-Headers"))
+		assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding,h1", resp.Header.Get("Access-Control-Expose-Headers"))
 		assert.Equal(t, "v1", resp.Header.Get("h1"))
 	})
 	t.Run("ok gzip", func(t *testing.T) {
@@ -181,7 +181,7 @@ func TestAPI_EvalAll(t *testing.T) {
 		_ = wr.Flush()
 		assert.Equal(t, buf.Bytes(), body)
 		assert.Equal(t, "*", resp.Header.Get("Access-Control-Allow-Origin"))
-		assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding", resp.Header.Get("Access-Control-Expose-Headers"))
+		assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding,h1", resp.Header.Get("Access-Control-Expose-Headers"))
 		assert.Equal(t, "v1", resp.Header.Get("h1"))
 	})
 	t.Run("get not allowed", func(t *testing.T) {
@@ -251,10 +251,10 @@ func TestAPI_Keys(t *testing.T) {
 
 		assert.Equal(t, "GET,OPTIONS", resp.Header.Get("Access-Control-Allow-Methods"))
 		assert.Equal(t, "false", resp.Header.Get("Access-Control-Allow-Credentials"))
-		assert.Equal(t, "Cache-Control,Content-Type,Content-Length,Accept-Encoding,If-None-Match", resp.Header.Get("Access-Control-Allow-Headers"))
+		assert.Equal(t, "Cache-Control,Content-Type,Content-Length,Accept-Encoding,If-None-Match,X-AUTH", resp.Header.Get("Access-Control-Allow-Headers"))
 		assert.Equal(t, "600", resp.Header.Get("Access-Control-Max-Age"))
 		assert.Equal(t, "*", resp.Header.Get("Access-Control-Allow-Origin"))
-		assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding", resp.Header.Get("Access-Control-Expose-Headers"))
+		assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding,h1", resp.Header.Get("Access-Control-Expose-Headers"))
 		assert.Equal(t, "v1", resp.Header.Get("h1"))
 	})
 	t.Run("missing auth", func(t *testing.T) {
@@ -262,7 +262,7 @@ func TestAPI_Keys(t *testing.T) {
 		resp, _ := client.Do(req)
 		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 		assert.Equal(t, "*", resp.Header.Get("Access-Control-Allow-Origin"))
-		assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding", resp.Header.Get("Access-Control-Expose-Headers"))
+		assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding,h1", resp.Header.Get("Access-Control-Expose-Headers"))
 		assert.Equal(t, "v1", resp.Header.Get("h1"))
 	})
 	t.Run("ok", func(t *testing.T) {
@@ -274,7 +274,7 @@ func TestAPI_Keys(t *testing.T) {
 		_ = resp.Body.Close()
 		assert.Equal(t, `{"keys":["flag"]}`, string(body))
 		assert.Equal(t, "*", resp.Header.Get("Access-Control-Allow-Origin"))
-		assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding", resp.Header.Get("Access-Control-Expose-Headers"))
+		assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding,h1", resp.Header.Get("Access-Control-Expose-Headers"))
 		assert.Equal(t, "v1", resp.Header.Get("h1"))
 	})
 	t.Run("ok gzip", func(t *testing.T) {
@@ -292,7 +292,7 @@ func TestAPI_Keys(t *testing.T) {
 		_ = wr.Flush()
 		assert.Equal(t, buf.Bytes(), body)
 		assert.Equal(t, "*", resp.Header.Get("Access-Control-Allow-Origin"))
-		assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding", resp.Header.Get("Access-Control-Expose-Headers"))
+		assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding,h1", resp.Header.Get("Access-Control-Expose-Headers"))
 		assert.Equal(t, "v1", resp.Header.Get("h1"))
 	})
 	t.Run("post not allowed", func(t *testing.T) {
@@ -362,10 +362,10 @@ func TestAPI_Refresh(t *testing.T) {
 
 		assert.Equal(t, "POST,OPTIONS", resp.Header.Get("Access-Control-Allow-Methods"))
 		assert.Equal(t, "false", resp.Header.Get("Access-Control-Allow-Credentials"))
-		assert.Equal(t, "Cache-Control,Content-Type,Content-Length,Accept-Encoding,If-None-Match", resp.Header.Get("Access-Control-Allow-Headers"))
+		assert.Equal(t, "Cache-Control,Content-Type,Content-Length,Accept-Encoding,If-None-Match,X-AUTH", resp.Header.Get("Access-Control-Allow-Headers"))
 		assert.Equal(t, "600", resp.Header.Get("Access-Control-Max-Age"))
 		assert.Equal(t, "*", resp.Header.Get("Access-Control-Allow-Origin"))
-		assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding", resp.Header.Get("Access-Control-Expose-Headers"))
+		assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding,h1", resp.Header.Get("Access-Control-Expose-Headers"))
 		assert.Equal(t, "v1", resp.Header.Get("h1"))
 	})
 	t.Run("missing auth", func(t *testing.T) {
@@ -373,7 +373,7 @@ func TestAPI_Refresh(t *testing.T) {
 		resp, _ := client.Do(req)
 		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 		assert.Equal(t, "*", resp.Header.Get("Access-Control-Allow-Origin"))
-		assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding", resp.Header.Get("Access-Control-Expose-Headers"))
+		assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding,h1", resp.Header.Get("Access-Control-Expose-Headers"))
 		assert.Equal(t, "v1", resp.Header.Get("h1"))
 	})
 	t.Run("ok", func(t *testing.T) {
@@ -385,7 +385,7 @@ func TestAPI_Refresh(t *testing.T) {
 		_ = resp.Body.Close()
 		assert.Equal(t, "", string(body))
 		assert.Equal(t, "*", resp.Header.Get("Access-Control-Allow-Origin"))
-		assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding", resp.Header.Get("Access-Control-Expose-Headers"))
+		assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding,h1", resp.Header.Get("Access-Control-Expose-Headers"))
 		assert.Equal(t, "v1", resp.Header.Get("h1"))
 	})
 	t.Run("get not allowed", func(t *testing.T) {

--- a/web/router_cdnproxy_test.go
+++ b/web/router_cdnproxy_test.go
@@ -28,7 +28,7 @@ func TestCDNProxy_Options_CORS(t *testing.T) {
 	assert.Equal(t, "Cache-Control,Content-Type,Content-Length,Accept-Encoding,If-None-Match", resp.Header.Get("Access-Control-Allow-Headers"))
 	assert.Equal(t, "600", resp.Header.Get("Access-Control-Max-Age"))
 	assert.Equal(t, "*", resp.Header.Get("Access-Control-Allow-Origin"))
-	assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding", resp.Header.Get("Access-Control-Expose-Headers"))
+	assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding,h1", resp.Header.Get("Access-Control-Expose-Headers"))
 	assert.Equal(t, "v1", resp.Header.Get("h1"))
 }
 
@@ -62,7 +62,7 @@ func TestCDNProxy_GET_CORS(t *testing.T) {
 	assert.Empty(t, resp.Header.Get("Access-Control-Allow-Headers"))
 	assert.Empty(t, resp.Header.Get("Access-Control-Max-Age"))
 	assert.Equal(t, "*", resp.Header.Get("Access-Control-Allow-Origin"))
-	assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding", resp.Header.Get("Access-Control-Expose-Headers"))
+	assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding,h1", resp.Header.Get("Access-Control-Expose-Headers"))
 	assert.Equal(t, "v1", resp.Header.Get("h1"))
 }
 

--- a/web/router_sse_test.go
+++ b/web/router_sse_test.go
@@ -27,7 +27,7 @@ func TestSSE_EvalFlag_Options_CORS(t *testing.T) {
 	assert.Equal(t, "Cache-Control,Content-Type,Content-Length,Accept-Encoding,If-None-Match", resp.Header.Get("Access-Control-Allow-Headers"))
 	assert.Equal(t, "600", resp.Header.Get("Access-Control-Max-Age"))
 	assert.Equal(t, "*", resp.Header.Get("Access-Control-Allow-Origin"))
-	assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding", resp.Header.Get("Access-Control-Expose-Headers"))
+	assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding,h1", resp.Header.Get("Access-Control-Expose-Headers"))
 	assert.Equal(t, "v1", resp.Header.Get("h1"))
 }
 
@@ -44,7 +44,7 @@ func TestSSE_EvalFlag_GET_CORS(t *testing.T) {
 	assert.Equal(t, "no-cache", resp.Header.Get("Cache-Control"))
 	assert.Equal(t, "keep-alive", resp.Header.Get("Connection"))
 	assert.Equal(t, "*", resp.Header.Get("Access-Control-Allow-Origin"))
-	assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding", resp.Header.Get("Access-Control-Expose-Headers"))
+	assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding,h1", resp.Header.Get("Access-Control-Expose-Headers"))
 	assert.Equal(t, "v1", resp.Header.Get("h1"))
 }
 
@@ -89,7 +89,7 @@ func TestSSE_EvalAllFlags_Options_CORS(t *testing.T) {
 	assert.Equal(t, "Cache-Control,Content-Type,Content-Length,Accept-Encoding,If-None-Match", resp.Header.Get("Access-Control-Allow-Headers"))
 	assert.Equal(t, "600", resp.Header.Get("Access-Control-Max-Age"))
 	assert.Equal(t, "*", resp.Header.Get("Access-Control-Allow-Origin"))
-	assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding", resp.Header.Get("Access-Control-Expose-Headers"))
+	assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding,h1", resp.Header.Get("Access-Control-Expose-Headers"))
 	assert.Equal(t, "v1", resp.Header.Get("h1"))
 
 	data := base64.URLEncoding.EncodeToString([]byte(`{"user":"{}"}`))
@@ -102,7 +102,7 @@ func TestSSE_EvalAllFlags_Options_CORS(t *testing.T) {
 	assert.Equal(t, "Cache-Control,Content-Type,Content-Length,Accept-Encoding,If-None-Match", resp.Header.Get("Access-Control-Allow-Headers"))
 	assert.Equal(t, "600", resp.Header.Get("Access-Control-Max-Age"))
 	assert.Equal(t, "*", resp.Header.Get("Access-Control-Allow-Origin"))
-	assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding", resp.Header.Get("Access-Control-Expose-Headers"))
+	assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding,h1", resp.Header.Get("Access-Control-Expose-Headers"))
 	assert.Equal(t, "v1", resp.Header.Get("h1"))
 }
 
@@ -118,7 +118,7 @@ func TestSSE_EvalAllFlags_GET_CORS(t *testing.T) {
 	assert.Equal(t, "no-cache", resp.Header.Get("Cache-Control"))
 	assert.Equal(t, "keep-alive", resp.Header.Get("Connection"))
 	assert.Equal(t, "*", resp.Header.Get("Access-Control-Allow-Origin"))
-	assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding", resp.Header.Get("Access-Control-Expose-Headers"))
+	assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding,h1", resp.Header.Get("Access-Control-Expose-Headers"))
 	assert.Equal(t, "v1", resp.Header.Get("h1"))
 
 	data := base64.URLEncoding.EncodeToString([]byte(`{"user":"{}"}`))
@@ -130,7 +130,7 @@ func TestSSE_EvalAllFlags_GET_CORS(t *testing.T) {
 	assert.Equal(t, "no-cache", resp.Header.Get("Cache-Control"))
 	assert.Equal(t, "keep-alive", resp.Header.Get("Connection"))
 	assert.Equal(t, "*", resp.Header.Get("Access-Control-Allow-Origin"))
-	assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding", resp.Header.Get("Access-Control-Expose-Headers"))
+	assert.Equal(t, "Content-Length,ETag,Date,Content-Encoding,h1", resp.Header.Get("Access-Control-Expose-Headers"))
 	assert.Equal(t, "v1", resp.Header.Get("h1"))
 }
 


### PR DESCRIPTION
### Describe the purpose of your pull request

Headers listed in `auth_headers` option are now put into the CORS `Access-Control-Allow-Headers` header.
Similarly, headers listed in `headers` option are now put into the CORS `Access-Control-Expose-Headers`.

### Related issues (only if applicable)

n/a

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
