### PR TITLE
Release Docker images to arm64 & amd64 architectures

### DIFF
--- a/.github/workflows/proxy-release.yml
+++ b/.github/workflows/proxy-release.yml
@@ -52,6 +52,16 @@ jobs:
         with:
           go-version: stable
 
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: amd64,arm64
+        
+      - name: Setup Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
+
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -30,9 +30,10 @@ archives:
 
 dockers:
   - image_templates:
-    - "configcat/proxy:{{.Version}}"
-    - "configcat/proxy:v{{.Major}}"
-    - "configcat/proxy:latest"
+    - "configcat/proxy:{{.Version}}-amd64"
+    - "configcat/proxy:v{{.Major}}-amd64"
+    - "configcat/proxy:latest-amd64"
+    use: buildx
     goos: linux
     goarch: amd64
     dockerfile: Dockerfile.goreleaser
@@ -40,3 +41,36 @@ dockers:
     build_flag_templates:
       - "--pull"
       - "--platform=linux/amd64"
+  
+  - image_templates:
+    - "configcat/proxy:{{.Version}}-arm64"
+    - "configcat/proxy:v{{.Major}}-arm64"
+    - "configcat/proxy:latest-arm64"
+    use: buildx
+    goos: linux
+    goarch: arm64
+    dockerfile: Dockerfile.goreleaser
+    skip_push: false
+    build_flag_templates:
+      - "--pull"
+      - "--platform=linux/arm64"
+
+docker_manifests:
+  - name_template: "configcat/proxy:{{.Version}}"
+    skip_push: false
+    image_templates:
+    - "configcat/proxy:{{.Version}}-amd64"
+    - "configcat/proxy:{{.Version}}-arm64"
+  
+  - name_template: "configcat/proxy:v{{.Major}}"
+    skip_push: false
+    image_templates:
+    - "configcat/proxy:v{{.Major}}-amd64"
+    - "configcat/proxy:v{{.Major}}-arm64"
+
+  - name_template: "configcat/proxy:latest"
+    skip_push: false
+    image_templates:
+    - "configcat/proxy:latest-amd64"
+    - "configcat/proxy:latest-arm64"
+


### PR DESCRIPTION
### Describe the purpose of your pull request

This PR enables the publishing of docker images for both `linux/amd64` and `linux/arm64` architectures.

### Related issues (only if applicable)

- #25 

### Requirement checklist (only if applicable)

- [ ] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
