### PR TITLE
Support overriding the diagnostics service name

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -236,11 +236,12 @@ type TlsConfig struct {
 }
 
 type DiagConfig struct {
-	Port    int           `yaml:"port"`
-	Enabled bool          `yaml:"enabled"`
-	Metrics MetricsConfig `yaml:"metrics"`
-	Traces  TraceConfig   `yaml:"traces"`
-	Status  StatusConfig  `yaml:"status"`
+	Port        int           `yaml:"port"`
+	Enabled     bool          `yaml:"enabled"`
+	ServiceName string        `yaml:"service_name"`
+	Metrics     MetricsConfig `yaml:"metrics"`
+	Traces      TraceConfig   `yaml:"traces"`
+	Status      StatusConfig  `yaml:"status"`
 }
 
 type MetricsConfig struct {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -490,6 +490,7 @@ func TestDiagConfig_YAML(t *testing.T) {
 diag:
   enabled: false
   port: 8091
+  service_name: "custom-proxy"
   status:
     enabled: false
   metrics:
@@ -513,6 +514,7 @@ diag:
 
 		assert.False(t, conf.Diag.Enabled)
 		assert.Equal(t, 8091, conf.Diag.Port)
+		assert.Equal(t, "custom-proxy", conf.Diag.ServiceName)
 		assert.False(t, conf.Diag.Status.Enabled)
 		assert.False(t, conf.Diag.Metrics.Enabled)
 		assert.False(t, conf.Diag.Metrics.Prometheus.Enabled)

--- a/config/env.go
+++ b/config/env.go
@@ -418,6 +418,7 @@ func (d *DiagConfig) loadEnv(prefix string) error {
 	if err := readEnv(prefix, "PORT", &d.Port, toInt); err != nil {
 		return err
 	}
+	readEnvString(prefix, "SERVICE_NAME", &d.ServiceName)
 	if err := d.Status.loadEnv(prefix); err != nil {
 		return err
 	}

--- a/config/env_test.go
+++ b/config/env_test.go
@@ -214,12 +214,14 @@ func TestDiagConfig_ENV(t *testing.T) {
 	t.Setenv("CONFIGCAT_DIAG_TRACES_OTLP_ENABLED", "true")
 	t.Setenv("CONFIGCAT_DIAG_TRACES_OTLP_PROTOCOL", "grpc")
 	t.Setenv("CONFIGCAT_DIAG_TRACES_OTLP_ENDPOINT", "http://localhost:4317")
+	t.Setenv("CONFIGCAT_DIAG_SERVICE_NAME", "custom-proxy")
 
 	conf, err := LoadConfigFromFileAndEnvironment("")
 	require.NoError(t, err)
 
 	assert.False(t, conf.Diag.Enabled)
 	assert.Equal(t, 8091, conf.Diag.Port)
+	assert.Equal(t, "custom-proxy", conf.Diag.ServiceName)
 	assert.False(t, conf.Diag.Status.Enabled)
 	assert.False(t, conf.Diag.Metrics.Enabled)
 	assert.False(t, conf.Diag.Metrics.Prometheus.Enabled)

--- a/diag/telemetry/metrics_test.go
+++ b/diag/telemetry/metrics_test.go
@@ -127,7 +127,7 @@ func TestOtlpMetricsExporterGrpc(t *testing.T) {
 	assert.NoError(t, err)
 	defer collector.Shutdown()
 
-	handler := newMetricsHandler(t.Context(), buildResource("0.1.0"),
+	handler := newMetricsHandler(t.Context(), buildResource("", "0.1.0"),
 		&config.MetricsConfig{Enabled: true, Otlp: config.OtlpExporterConfig{Enabled: true, Protocol: "grpc", Endpoint: collector.Addr()}}, log.NewNullLogger())
 	assert.NotNil(t, handler)
 
@@ -141,7 +141,7 @@ func TestOtlpMetricsExporterHttp(t *testing.T) {
 	collector := newInMemoryMetricHttpCollector()
 	defer collector.Shutdown()
 
-	handler := newMetricsHandler(t.Context(), buildResource("0.1.0"),
+	handler := newMetricsHandler(t.Context(), buildResource("", "0.1.0"),
 		&config.MetricsConfig{Enabled: true, Otlp: config.OtlpExporterConfig{Enabled: true, Protocol: "http", Endpoint: collector.Addr()}}, log.NewNullLogger())
 	assert.NotNil(t, handler)
 

--- a/diag/telemetry/reporter.go
+++ b/diag/telemetry/reporter.go
@@ -75,7 +75,7 @@ type reporter struct {
 
 func NewReporter(conf *config.DiagConfig, version string, log log.Logger) Reporter {
 	logger := log.WithPrefix("telemetry")
-	res := buildResource(version)
+	res := buildResource(conf.ServiceName, version)
 
 	var mh *metricsHandler
 	var th *traceHandler
@@ -230,12 +230,15 @@ func (r *reporter) Shutdown() {
 	}
 }
 
-func buildResource(version string) *resource.Resource {
+func buildResource(serviceName, version string) *resource.Resource {
+	if serviceName == "" {
+		serviceName = "configcat-proxy"
+	}
 	res, _ := resource.Merge(
 		resource.Default(),
 		resource.NewWithAttributes(
 			semconv.SchemaURL,
-			semconv.ServiceName("configcat-proxy"),
+			semconv.ServiceName(serviceName),
 			semconv.ServiceVersion(version),
 		))
 	return res

--- a/diag/telemetry/reporter_test.go
+++ b/diag/telemetry/reporter_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/testcontainers/testcontainers-go/modules/mongodb"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
+	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
 	"go.opentelemetry.io/otel/trace/noop"
 	"google.golang.org/grpc"
 )
@@ -328,4 +329,19 @@ func Test_Empty_Instrument(t *testing.T) {
 	assert.Empty(t, conf.APIOptions)
 
 	handler.Shutdown()
+}
+
+func TestBuildResource_ServiceName(t *testing.T) {
+	t.Run("defaults when empty", func(t *testing.T) {
+		res := buildResource("", "0.1.0")
+		name, ok := res.Set().Value(semconv.ServiceNameKey)
+		assert.True(t, ok)
+		assert.Equal(t, "configcat-proxy", name.AsString())
+	})
+	t.Run("overrides when set", func(t *testing.T) {
+		res := buildResource("custom-proxy", "0.1.0")
+		name, ok := res.Set().Value(semconv.ServiceNameKey)
+		assert.True(t, ok)
+		assert.Equal(t, "custom-proxy", name.AsString())
+	})
 }

--- a/diag/telemetry/traces_test.go
+++ b/diag/telemetry/traces_test.go
@@ -28,7 +28,7 @@ func TestOtlpTracesExporterGrpc(t *testing.T) {
 	assert.NoError(t, err)
 	defer collector.Shutdown()
 
-	handler := newTraceHandler(t.Context(), buildResource("0.1.0"),
+	handler := newTraceHandler(t.Context(), buildResource("", "0.1.0"),
 		&config.TraceConfig{Enabled: true, Otlp: config.OtlpExporterConfig{Enabled: true, Protocol: "grpc", Endpoint: collector.Addr()}}, log.NewNullLogger())
 	assert.NotNil(t, handler)
 	defer handler.Shutdown()
@@ -45,7 +45,7 @@ func TestOtlpTracesExporterHttp(t *testing.T) {
 	collector := newInMemoryTraceHttpCollector()
 	defer collector.Shutdown()
 
-	handler := newTraceHandler(t.Context(), buildResource("0.1.0"),
+	handler := newTraceHandler(t.Context(), buildResource("", "0.1.0"),
 		&config.TraceConfig{Enabled: true, Otlp: config.OtlpExporterConfig{Enabled: true, Protocol: "http", Endpoint: collector.Addr()}}, log.NewNullLogger())
 	assert.NotNil(t, handler)
 	defer handler.Shutdown()


### PR DESCRIPTION
## Summary

This pull request lets each ConfigCat Proxy deployment configure the OpenTelemetry service name used for diagnostics telemetry.

## Motivation

Multiple ConfigCat Proxy deployments can run in the same Kubernetes cluster or observability environment. A fixed service name makes their OTLP metrics and traces appear under the same `service.name` resource attribute, which makes monitoring and filtering ambiguous.

This setting lets operators assign a distinct service name per deployment, for example when different proxies serve different environments, tenants, network zones, or traffic paths.

## Fix

The key behavior change is in the telemetry reporter. The reporter now builds the OpenTelemetry resource from the configured diagnostics service name instead of always writing the fixed value:

```diff
- res := buildResource(version)
+ res := buildResource(conf.ServiceName, version)

- semconv.ServiceName("configcat-proxy"),
+ semconv.ServiceName(serviceName),
```

The YAML and environment configuration changes only provide this value through the existing diagnostics configuration path.

## Changes

- Adds `diag.service_name` to the YAML configuration.
- Adds `CONFIGCAT_DIAG_SERVICE_NAME` as the matching environment override.
- Uses the configured value for the OpenTelemetry `service.name` resource attribute.

## Compatibility

When no service name is configured, ConfigCat Proxy keeps using `configcat-proxy`.

## Testing

- `go fmt ./...`
- `go vet -tags testing ./...`
- `go test -tags testing -race ./config -run TestDiagConfig`
- `go test -tags testing -race ./diag/telemetry -run TestBuildResource_ServiceName`

Closes #54.
